### PR TITLE
Test prev3

### DIFF
--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -161,10 +161,10 @@ jobs:
         make -j V=0
         make -j check V=0
         make -j distcheck V=0
-        mv t8code-*.tar.gz ..
+        mv t8-*.tar.gz ..
         cd ..
     - name: Save tarball
       uses: actions/upload-artifact@v2
       with:
         name: t8code_tarball
-        path: ./t8code-*.tar.gz
+        path: ./t8-*.tar.gz

--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -154,8 +154,10 @@ jobs:
       run: |
         DIR="tarball" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror -Wno-unused-parameter \
-                    -Wno-builtin-declaration-mismatch -Wno-implicit-fallthrough"
+            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror
+                    -Wno-unused-parameter -Wno-type-limits
+                    -Wno-builtin-declaration-mismatch
+                    -Wno-implicit-fallthrough"
         make -j V=0
         make -j check V=0
         make -j distcheck V=0

--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -154,9 +154,9 @@ jobs:
       run: |
         DIR="tarball" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror
-                    -Wno-unused-parameter -Wno-type-limits
-                    -Wno-builtin-declaration-mismatch
+            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
+                    -Wno-unused-parameter -Wno-type-limits \
+                    -Wno-builtin-declaration-mismatch \
                     -Wno-implicit-fallthrough"
         make -j V=0
         make -j check V=0

--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -1,0 +1,168 @@
+name: CI for Autotools
+
+# This script is derived from ci.yml of p4est
+
+on: [push, pull_request]
+
+jobs:
+
+  linux-multi:
+    runs-on: ubuntu-latest
+    name: Autotools build on Linux
+    steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -yq
+        sudo apt-get install -yq --no-install-recommends \
+            zlib1g-dev libmpich-dev mpich
+    - name: Checkout source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Run bootstrap script
+      run: ./bootstrap
+    - name: Make check with debug, without shared
+      shell: bash
+      run: |
+        DIR="checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --disable-shared --enable-debug \
+            CFLAGS="-O0 -g -Wall"
+        make -j V=0
+        make -j check V=0
+        cd ..
+    - name: Make check with MPI and debug
+      shell: bash
+      run: |
+        DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --enable-mpi --enable-debug \
+            CFLAGS="-O0 -g -Wall"
+        make -j V=0
+        make -j check V=0
+        cd ..
+    - name: Make check with MPI, without debug
+      shell: bash
+      run: |
+        DIR="checkMPI" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --enable-mpi \
+            CFLAGS="-O2"
+        make -j V=0
+        make -j check V=0
+        cd ..
+    - name: Make check with MPI, debug and C++ compiler
+      shell: bash
+      run: |
+        DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --enable-mpi --enable-debug \
+            CFLAGS="-O0" CC=mpicxx
+        make -j V=0
+        make -j check V=0
+        cd ..
+    - name: Make distcheck without MPI and debug
+      shell: bash
+      run: |
+        DIR="distcheck" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure
+        make -j distcheck V=0
+        cd ..
+    - name: Save test suite log
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test_suite_log
+        path: ./**/test-suite.log
+
+  linux-install:
+    runs-on: ubuntu-latest
+    name: Make install on Linux
+    steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -yq
+        sudo apt-get install -yq --no-install-recommends \
+            zlib1g-dev libmpich-dev mpich
+    - name: Checkout source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Fix libsc to version 2.8.3
+      shell: bash
+      run: (cd sc && git fetch --tags && git checkout v2.8.3)
+    - name: Fix p4est to version 2.8
+      shell: bash
+      run: (cd p4est && git fetch --tags && git checkout v2.8)
+    - name: Run bootstrap script
+      run: ./bootstrap
+    - name: Install libsc with debug, without shared
+      shell: bash
+      run: |
+        DIR="sc-checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
+        ../sc/configure --disable-shared --enable-debug \
+            CFLAGS="-O0 -g -Wall -pedantic"
+        make -j V=0
+        make -j check V=0
+        make -j install V=0
+        cd ..
+        rm -rf sc/
+    - name: Install p4est with debug, without shared
+      shell: bash
+      run: |
+        DIR="p4est-checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
+        ../p4est/configure --disable-shared --enable-debug \
+            --with-sc="$PWD/../sc-checkdebug_static/local" \
+            CFLAGS="-O0 -g -Wall -pedantic"
+        make -j V=0
+        make -j check V=0
+        make -j install V=0
+        cd ..
+        rm -rf sc/
+    - name: Install t8code with debug, without shared
+      shell: bash
+      run: |
+        DIR="t8code-checkdebug_static" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --disable-shared --enable-debug \
+            --with-sc="$PWD/../sc-checkdebug_static/local" \
+            --with-p4est="$PWD/../p4est-checkdebug_static/local" \
+            CFLAGS="-O0 -g -Wall -pedantic"
+        make -j V=0
+        make -j check V=0
+        make -j install V=0
+        cd ..
+
+  linux-tarball:
+    runs-on: ubuntu-latest
+    name: Pack tarball on Linux
+    steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -yq
+        sudo apt-get install -yq --no-install-recommends \
+            zlib1g-dev libmpich-dev mpich
+    - name: Checkout source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Identify version
+      shell: bash
+      run: |
+        git tag
+        git describe --abbrev=4 --match 'v*'
+    - name: Run bootstrap script
+      run: ./bootstrap
+    - name: Configure and make
+      shell: bash
+      run: |
+        DIR="tarball" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --enable-mpi --enable-debug \
+            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror -Wno-unused-parameter \
+                    -Wno-builtin-declaration-mismatch -Wno-implicit-fallthrough"
+        make -j V=0
+        make -j check V=0
+        make -j distcheck V=0
+        mv t8code-*.tar.gz ..
+        cd ..
+    - name: Save tarball
+      uses: actions/upload-artifact@v2
+      with:
+        name: t8code_tarball
+        path: ./t8code-*.tar.gz

--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            zlib1g-dev libmpich-dev mpich
+            zlib1g-dev libmpich-dev mpich pandoc
     - name: Checkout source code
       uses: actions/checkout@v2
       with:
@@ -79,7 +79,7 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            zlib1g-dev libmpich-dev mpich
+            zlib1g-dev libmpich-dev mpich pandoc
     - name: Checkout source code
       uses: actions/checkout@v2
       with:
@@ -136,7 +136,7 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            zlib1g-dev libmpich-dev mpich
+            zlib1g-dev libmpich-dev mpich pandoc
     - name: Checkout source code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci_autotools.yml
+++ b/.github/workflows/ci_autotools.yml
@@ -30,15 +30,15 @@ jobs:
         make -j V=0
         make -j check V=0
         cd ..
-    - name: Make check with MPI and debug
-      shell: bash
-      run: |
-        DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -Wall"
-        make -j V=0
-        make -j check V=0
-        cd ..
+#    - name: Make check with MPI and debug
+#      shell: bash
+#      run: |
+#        DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
+#        ../configure --enable-mpi --enable-debug \
+#            CFLAGS="-O0 -g -Wall"
+#        make -j V=0
+#        make -j check V=0
+#        cd ..
     - name: Make check with MPI, without debug
       shell: bash
       run: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 # Makefile.am in toplevel directory
 
 # include makefiles from installed subpackages
-ACLOCAL_AMFLAGS = -I config @T8_SC_AMFLAGS@ @T8_P4EST_AMFLAGS@
+ACLOCAL_AMFLAGS = -I config
 if T8_SC_MK_USE
 @T8_SC_MK_INCLUDE@
 endif
@@ -29,6 +29,9 @@ noinst_HEADERS =
 noinst_PROGRAMS =
 sysconf_DATA =
 dist_t8data_DATA =
+
+# pkg-config configuration file
+pkgconfig_DATA =
 
 # use this if you want to link in T8 without autotools
 sysconf_DATA += Makefile.t8.mk

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,7 @@ SUBDIRS = @T8_SC_SUBDIR@ @T8_P4EST_SUBDIR@
 DIST_SUBDIRS = $(SUBDIRS)
 
 # handle toplevel directory
-EXTRA_DIST += \
+EXTRA_DIST += README.md \
   bootstrap build-aux/git-version-gen build-aux/git2cl scripts doc
 DISTCLEANFILES += \
         _configs.sed src/t8_config.h @T8_DISTCLEAN@

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,11 +98,13 @@ ChangeLog:
 
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
-	test "x$(VERSION)" = "x`@top_srcdir@/build-aux/git-version-gen \
-          @top_srcdir@/.tarball-version`" || \
-        ((echo "Stale version;" ; echo "Please run:" ; \
-          echo "     cd @top_srcdir@ && ./bootstrap" ; \
-          echo "before make dist") 1>&2 ; rm -r $(distdir) ; exit 1)
+	(GITGEN_VERSION=`(cd @top_srcdir@ && ./build-aux/git-version-gen\
+	        .tarball-version)` ; \
+	 test "x$(VERSION)" = "x$${GITGEN_VERSION}" || \
+	 ((echo "Stale version;"; echo $(VERSION); echo "$${GITGEN_VERSION}"; \
+	   echo "Please run:" ; \
+	   echo "     (cd @top_srcdir@ && ./bootstrap)" ; \
+	   echo "before make dist") 1>&2 ; rm -r $(distdir) ; exit 1))
 if T8_DIST_DENY
 	@echo "-----------------------------------------------------"
 	@echo "make dist does not work with external subpackages"

--- a/bootstrap
+++ b/bootstrap
@@ -51,13 +51,4 @@ fi
 echo "--- This is the bootstrap script for t8code ---"
 echo "Current directory is $PWD"
 
-LIBTOOLIZE=`which glibtoolize`
-if test ! -x "$LIBTOOLIZE" ; then LIBTOOLIZE=`which libtoolize` ; fi
-if test ! -x "$LIBTOOLIZE" ; then echo "bootstrap requires libtoolize" ; \
-   exit 1 ; fi
-
-aclocal -Wall -I config -I "$SC_CONFIG" -I "$P4EST_CONFIG"
-autoconf -Wall --force
-autoheader -Wall --force
-"$LIBTOOLIZE" --install --copy
-automake -Wall --add-missing --copy
+autoreconf -i -I "$SC_CONFIG" -I "$P4EST_CONFIG"

--- a/bootstrap
+++ b/bootstrap
@@ -51,4 +51,5 @@ fi
 echo "--- This is the bootstrap script for t8code ---"
 echo "Current directory is $PWD"
 
+rm -rf autom4te.cache
 autoreconf -i -I "$SC_CONFIG" -I "$P4EST_CONFIG"

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,13 +1,13 @@
 #!/bin/sh
 # Print a version string.
-scriptversion=2008-04-08.07
+scriptversion=2019-10-13.15; # UTC
 
-# Copyright (C) 2007-2008 Free Software Foundation
+# Copyright (C) 2007-2021 Free Software Foundation, Inc.
 #
-# This program is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -15,11 +15,9 @@ scriptversion=2008-04-08.07
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# This script is derived from GIT-VERSION-GEN from GIT: http://git.or.cz/.
+# This script is derived from GIT-VERSION-GEN from GIT: https://git-scm.com/.
 # It may be run two ways:
 # - from a git repository in which the "git describe" command below
 #   produces useful output (thus requiring at least one signed tag)
@@ -46,8 +44,10 @@ scriptversion=2008-04-08.07
 #   files to pick up a version string change; and leave it stale to
 #   minimize rebuild time after unrelated changes to configure sources.
 #
-# It is probably wise to add these two files to .gitignore, so that you
-# don't accidentally commit either generated file.
+# As with any generated file in a VC'd directory, you should add
+# /.version to .gitignore, so that you don't accidentally commit it.
+# .tarball-version is never generated in a VC'd directory, so needn't
+# be listed there.
 #
 # Use the following line in your configure.ac, so that $(VERSION) will
 # automatically be up-to-date each time configure is run (and note that
@@ -59,104 +59,168 @@ scriptversion=2008-04-08.07
 #         [bug-project@example])
 #
 # Then use the following lines in your Makefile.am, so that .version
-# will be present for dependencies, and so that .tarball-version will
-# exist in distribution tarballs.
+# will be present for dependencies, and so that .version and
+# .tarball-version will exist in distribution tarballs.
 #
+# EXTRA_DIST = $(top_srcdir)/.version
 # BUILT_SOURCES = $(top_srcdir)/.version
 # $(top_srcdir)/.version:
 #	echo $(VERSION) > $@-t && mv $@-t $@
 # dist-hook:
 #	echo $(VERSION) > $(distdir)/.tarball-version
 
-# Copyright (C) 2014 Carsten Burstedde
-#
-# With the new style of git submodules, .git may be a file: added test -f .git
 
-case $# in
-  1) ;;
-  *) echo 1>&2 "Usage: $0 \$srcdir/.tarball-version"; exit 1;;
-esac
+me=$0
 
-srcdir=`dirname $1`
-tarball_version_file=`basename $1`
+year=`expr "$scriptversion" : '\([^-]*\)'`
+version="git-version-gen $scriptversion
+
+Copyright $year Free Software Foundation, Inc.
+There is NO warranty.  You may redistribute this software
+under the terms of the GNU General Public License.
+For more information about these matters, see the files named COPYING."
+
+usage="\
+Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Print a version string.
+
+Options:
+
+   --prefix PREFIX    prefix of git tags (default 'v')
+   --fallback VERSION
+                      fallback version to use if \"git --version\" fails
+
+   --help             display this help and exit
+   --version          output version information and exit
+
+Running without arguments will suffice in most cases."
+
+prefix=v
+fallback=
+
+while test $# -gt 0; do
+  case $1 in
+    --help) echo "$usage"; exit 0;;
+    --version) echo "$version"; exit 0;;
+    --prefix) shift; prefix=${1?};;
+    --fallback) shift; fallback=${1?};;
+    -*)
+      echo "$0: Unknown option '$1'." >&2
+      echo "$0: Try '--help' for more information." >&2
+      exit 1;;
+    *)
+      if test "x$tarball_version_file" = x; then
+        tarball_version_file="$1"
+      elif test "x$tag_sed_script" = x; then
+        tag_sed_script="$1"
+      else
+        echo "$0: extra non-option argument '$1'." >&2
+        exit 1
+      fi;;
+  esac
+  shift
+done
+
+if test "x$tarball_version_file" = x; then
+    echo "$usage"
+    exit 1
+fi
+
+tag_sed_script="${tag_sed_script:-s/x/x/}"
+
 nl='
 '
 
-# Change directory into the srcdir.  This should allow
-# for out of source make dist.
-cd $srcdir
+# Avoid meddling by environment variable of the same name.
+v=
+v_from_git=
 
 # First see if there is a tarball-only version file.
 # then try "git describe", then default.
 if test -f $tarball_version_file
 then
-  v=`cat $tarball_version_file` || exit 1
-  case $v in
-    *$nl*) v= ;; # reject multi-line output
-    [0-9]*) ;;
-    *) v= ;;
-  esac
-  test -z "$v" \
-  && echo "$0: WARNING: $tarball_version_file seems to be damaged" 1>&2
+    v=`cat $tarball_version_file` || v=
+    case $v in
+        *$nl*) v= ;; # reject multi-line output
+    esac
+    test "x$v" = x \
+        && echo "$0: WARNING: $tarball_version_file is damaged" 1>&2
 fi
 
-
-if test -n "$v"
+if test "x$v" != x
 then
-  : # use $v
-elif { test -d .git || test -f .git ; } \
-  && v=`git describe --abbrev=4 --match='v*' HEAD 2>/dev/null \
-  || git describe --abbrev=4 HEAD 2>/dev/null` \
-  && case $v in
-  v[0-9]*) ;;
-  *) (exit 1) ;;
-esac
+    : # use $v
+# Otherwise, if there is at least one git commit involving the working
+# directory, and "git describe" output looks sensible, use that to
+# derive a version string.
+elif test "`git log -1 --pretty=format:x . 2>&1`" = x \
+    && v=`git describe --abbrev=4 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --abbrev=4 HEAD 2>/dev/null` \
+    && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
+    && case $v in
+         $prefix[0-9]*) ;;
+         *) (exit 1) ;;
+       esac
 then
-  # Is this a new git that lists number of commits since the last
-  # tag or the previous older version that did not?
-  #   Newer: v6.10-77-g0f8faeb
-  #   Older: v6.10-g0f8faeb
-  case $v in
-    *-*-*) : git describe is okay three part flavor ;;
-    *-*)
-    : git describe is older two part flavor
-    # Recreate the number of commits and rewrite such that the
-    # result is the same as if we were using the newer version
-    # of git describe.
-    vtag=`echo "$v" | sed 's/-.*//'`
-    numcommits=`git rev-list "$vtag"..HEAD | wc -l`
-    v=`echo "$v" | sed "s/\(.*\)-\(.*\)/\1-$numcommits-\2/"`;
-    ;;
-  esac
+    # Is this a new git that lists number of commits since the last
+    # tag or the previous older version that did not?
+    #   Newer: v6.10-77-g0f8faeb
+    #   Older: v6.10-g0f8faeb
+    vprefix=`expr "X$v" : 'X\(.*\)-g[^-]*$'` || vprefix=$v
+    case $vprefix in
+        *-*) : git describe is probably okay three part flavor ;;
+        *)
+            : git describe is older two part flavor
+            # Recreate the number of commits and rewrite such that the
+            # result is the same as if we were using the newer version
+            # of git describe.
+            vtag=`echo "$v" | sed 's/-.*//'`
+            commit_list=`git rev-list "$vtag"..HEAD 2>/dev/null` \
+                || { commit_list=failed;
+                     echo "$0: WARNING: git rev-list failed" 1>&2; }
+            numcommits=`echo "$commit_list" | wc -l`
+            v=`echo "$v" | sed "s/\(.*\)-\(.*\)/\1-$numcommits-\2/"`;
+            test "$commit_list" = failed && v=UNKNOWN
+            ;;
+    esac
 
-    # Change the first '-' to a '.', so version-comparing tools work properly.
-    # Remove the "g" in git describe's output string, to save a byte.
-    v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
-else
+    # Change the penultimate "-" to ".", for version-comparing tools.
+    # Remove the "g" to save a byte.
+    v=`echo "$v" | sed 's/-\([^-]*\)-g\([^-]*\)$/.\1-\2/'`;
+    v_from_git=1
+elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
     v=UNKNOWN
+else
+    v=$fallback
 fi
 
-v=`echo "$v" |sed 's/^v//'`
+v=`echo "$v" |sed "s/^$prefix//"`
 
-# Don't declare a version "dirty" merely because a time stamp has changed.
-git status > /dev/null 2>&1
+# Test whether to append the "-dirty" suffix only if the version
+# string we're using came from git.  I.e., skip the test if it's "UNKNOWN"
+# or if it came from .tarball-version.
+if test "x$v_from_git" != x; then
+  # Don't declare a version "dirty" merely because a timestamp has changed.
+  git update-index --refresh > /dev/null 2>&1
 
-dirty=`sh -c 'git diff-index --name-only HEAD' 2>/dev/null` || dirty=
-case "$dirty" in
-  '') ;;
-  *) # Append the suffix only if there isn't one already.
-  case $v in
-    *-dirty) ;;
-    *) v="$v-dirty" ;;
-  esac ;;
-esac
+  dirty=`exec 2>/dev/null;git diff-index --name-only HEAD` || dirty=
+  case "$dirty" in
+      '') ;;
+      *) # Append the suffix only if there isn't one already.
+          case $v in
+            *-dirty) ;;
+            *) v="$v-dirty" ;;
+          esac ;;
+  esac
+fi
 
 # Omit the trailing newline, so that m4_esyscmd can use the result directly.
-echo "$v" | tr -d '\012'
+printf %s "$v"
 
 # Local variables:
-# eval: (add-hook 'write-file-hooks 'time-stamp)
+# eval: (add-hook 'before-save-hook 'time-stamp)
 # time-stamp-start: "scriptversion="
 # time-stamp-format: "%:y-%02m-%02d.%02H"
-# time-stamp-end: "$"
+# time-stamp-time-zone: "UTC0"
+# time-stamp-end: "; # UTC"
 # End:

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PREFIX_DEFAULT([$PWD/local])
 AX_PREFIX_CONFIG_H([src/t8_config.h])
 AM_INIT_AUTOMAKE([parallel-tests subdir-objects])
 AM_SILENT_RULES
+PKG_INSTALLDIR
 SC_VERSION([T8])
 
 echo "o---------------------------------------"
@@ -32,8 +33,8 @@ SC_MPI_CONFIG([T8], [], [yes])
 SC_MPI_ENGAGE([T8])
 # This is needed for compatibility with automake >= 1.12
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
-SC_PROG_LINT
-SC_C_VERSION
+dnl SC_PROG_LINT
+dnl SC_C_VERSION
 LT_INIT
 
 echo "o---------------------------------------"

--- a/example/tutorials/Makefile.am
+++ b/example/tutorials/Makefile.am
@@ -18,14 +18,15 @@ example_tutorials_t8_step2_uniform_forest_SOURCES = \
 	example/tutorials/t8_step2_uniform_forest.cxx
 example_tutorials_t8_step3_adapt_forest_SOURCES = \
 	example/tutorials/t8_step3_adapt_forest.cxx \
-	example/tutorials/t8_step3_main.cxx
+	example/tutorials/t8_step3_main.cxx \
+	example/tutorials/t8_step3.h
 example_tutorials_t8_step4_partition_balance_ghost_SOURCES = \
 	example/tutorials/t8_step3_adapt_forest.cxx \
 	example/tutorials/t8_step4_partition_balance_ghost.cxx \
-	example/tutorials/t8_step4_main.cxx
+	example/tutorials/t8_step4_main.cxx \
+	example/tutorials/t8_step4.h
 example_tutorials_t8_step5_element_data_SOURCES = \
 	example/tutorials/t8_step3_adapt_forest.cxx \
 	example/tutorials/t8_step5_element_data.cxx \
-	example/tutorials/t8_step5_main.cxx
-
-
+	example/tutorials/t8_step5_main.cxx \
+	example/tutorials/t8_step5.h

--- a/src/t8_cmesh/t8_cmesh_types.h
+++ b/src/t8_cmesh/t8_cmesh_types.h
@@ -33,6 +33,8 @@
  * We define here the datatypes needed for internal cmesh routines.
  */
 
+T8_EXTERN_C_BEGIN ();
+
 typedef struct t8_part_tree *t8_part_tree_t;
 typedef struct t8_cmesh_trees *t8_cmesh_trees_t;
 typedef struct t8_cprofile t8_cprofile_t;       /* Defined below */
@@ -281,5 +283,7 @@ t8_cprofile_struct_t;
 
 /** The number of entries in a cprofile struct */
 #define T8_CPROFILE_NUM_STATS 9
+
+T8_EXTERN_C_END ();
 
 #endif /* !T8_CMESH_TYPES_H */

--- a/src/t8_data/t8_containers.cxx
+++ b/src/t8_data/t8_containers.cxx
@@ -28,8 +28,6 @@
 #include <sc_containers.h>
 #include <t8_data/t8_containers.h>
 
-T8_EXTERN_C_BEGIN ();
-
 #ifdef T8_ENABLE_DEBUG
 /* Query whether an element array is initialized properly. */
 static int
@@ -304,5 +302,3 @@ t8_element_array_truncate (t8_element_array_t * element_array)
   T8_ASSERT (t8_element_array_is_valid (element_array));
   sc_array_truncate (&element_array->array);
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_element_c_interface.cxx
+++ b/src/t8_element_c_interface.cxx
@@ -38,6 +38,14 @@ t8_element_maxlevel (t8_eclass_scheme_c * ts)
   return ts->t8_element_maxlevel ();
 }
 
+int
+t8_element_maxlevel_linearid (t8_eclass_scheme_c * ts)
+{
+  T8_ASSERT (ts != NULL);
+
+  return ts->t8_element_maxlevel_linearid ();
+}
+
 t8_eclass_t
 t8_element_child_eclass (t8_eclass_scheme_c * ts, int childid)
 {
@@ -147,6 +155,7 @@ t8_element_set_linear_id (t8_eclass_scheme_c * ts,
                           t8_element_t * elem, int level, t8_linearidx_t id)
 {
   T8_ASSERT (ts != NULL);
+  T8_ASSERT (0 <= level && level <= ts->t8_element_maxlevel_linearid ());
 
   ts->t8_element_set_linear_id (elem, level, id);
 }
@@ -156,6 +165,7 @@ t8_element_get_linear_id (t8_eclass_scheme_c * ts,
                           const t8_element_t * elem, int level)
 {
   T8_ASSERT (ts != NULL);
+  T8_ASSERT (0 <= level && level <= ts->t8_element_maxlevel_linearid ());
 
   return ts->t8_element_get_linear_id (elem, level);
 }

--- a/src/t8_element_c_interface.h
+++ b/src/t8_element_c_interface.h
@@ -41,6 +41,12 @@ T8_EXTERN_C_BEGIN ();
  */
 int                 t8_element_maxlevel (t8_eclass_scheme_c * ts);
 
+/** Return the maximum allowed level with working linearid functions.
+ * \param [in] ts             Implementation of a class scheme.
+ * \return                      The maximum allowed level for linear ids.
+ */
+int                 t8_element_maxlevel_linearid (t8_eclass_scheme_c * ts);
+
 /** Return the type of each child in the ordering of the implementation.
    * \param [in] ts             Implementation of a class scheme.
  * \param [in] childid  Must be between 0 and the number of children (exclusive).
@@ -197,6 +203,7 @@ void                t8_element_nca (t8_eclass_scheme_c * ts,
  * \param [in] ts             Implementation of a class scheme.
  * \param [in,out] elem The element whose entries will be set.
  * \param [in] level    The level of the uniform refinement to consider.
+ *                      Must be less equal \ref t8_element_maxlevel_linearid ().
  * \param [in] id       The linear id.
  *                      id must fulfil 0 <= id < 'number of leafs in the uniform refinement'
  */
@@ -209,6 +216,7 @@ void                t8_element_set_linear_id (t8_eclass_scheme_c * ts,
  * \param [in] ts             Implementation of a class scheme.
  * \param [in] elem     The element whose id we compute.
  * \param [in] level    The level of the uniform refinement to consider.
+ *                      Must be less equal \ref t8_element_maxlevel_linearid ().
  * \return              The linear id of the element.
  */
 t8_linearidx_t      t8_element_get_linear_id (t8_eclass_scheme_c * ts,

--- a/src/t8_element_cxx.cxx
+++ b/src/t8_element_cxx.cxx
@@ -68,6 +68,13 @@ t8_eclass_scheme::t8_element_array_index (sc_array_t * array, size_t it)
   return (t8_element_t *) sc_array_index (array, it);
 }
 
+/* Default implementation for the maximum linearid level */
+int
+t8_eclass_scheme::t8_element_maxlevel_linearid ()
+{
+  return t8_element_maxlevel ();
+}
+
 T8_EXTERN_C_END ();
 
 #if 0

--- a/src/t8_element_cxx.cxx
+++ b/src/t8_element_cxx.cxx
@@ -22,9 +22,6 @@
 
 #include <t8_element_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 #if 0
 t8_eclass_scheme_c::~t8_eclass_scheme_c ()
 {
@@ -74,8 +71,6 @@ t8_eclass_scheme::t8_element_maxlevel_linearid ()
 {
   return t8_element_maxlevel ();
 }
-
-T8_EXTERN_C_END ();
 
 #if 0
 void

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -77,6 +77,12 @@ public:
    */
   virtual int         t8_element_maxlevel (void) = 0;
 
+  /** Return the maximum allowed level for calling linearid functions.
+   * Defaults to \ref t8_element_maxlevel if not overriden by derived class.
+   * \return                      The maximum allowed level for linear ids to work.
+   */
+  virtual int         t8_element_maxlevel_linearid (void);
+
   /** Return the type of each child in the ordering of the implementation.
    * \param [in] childid  Must be between 0 and the number of children (exclusive).
    *                      The number of children is defined in \a t8_element_num_children.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -34,8 +34,6 @@
 #include <t8_eclass.h>
 #include <t8_element.h>
 
-T8_EXTERN_C_BEGIN ();
-
 /* TODO: Implement a set of rules that have to hold between different eclass,
  *       i.e. lines must have a greater or equal maxlevel than quads and triangles.
  *       Check whether this rules are fulfilled in the construction of a scheme.
@@ -753,7 +751,5 @@ void                t8_eclass_boundary_destroy (t8_scheme_t * scheme,
                                                 int min_dim, int length,
                                                 t8_element_t ** boundary);
 #endif /* if 0 */
-
-T8_EXTERN_C_END ();
 
 #endif /* !T8_ELEMENT_CXX_HXX */

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -26,9 +26,6 @@
 #include <t8_data/t8_containers.h>
 #include <t8_element_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* Check the lastly inserted elements of an array for recursive coarsening.
  * The last inserted element must be the last element of a family.
  * \param [in] forest  The new forest currently in construction.
@@ -418,5 +415,3 @@ t8_forest_adapt (t8_forest_t forest)
                            forest->profile->adapt_runtime);
   }
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_balance.cxx
+++ b/src/t8_forest/t8_forest_balance.cxx
@@ -28,9 +28,6 @@
 #include <t8_forest.h>
 #include <t8_element_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* This is the adapt function called during one round of balance.
  * We refine an element if it has any face neighbor with a level larger
  * than the element's level + 1.
@@ -391,5 +388,3 @@ t8_forest_is_balanced (t8_forest_t forest)
   forest->t8code_data = data_temp;
   return 1;
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -34,9 +34,6 @@
 #include <t8_cmesh/t8_cmesh_trees.h>
 #include <t8_cmesh/t8_cmesh_offset.h>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* Compute the maximum possible refinement level in a forest. */
 void
 t8_forest_compute_maxlevel (t8_forest_t forest)
@@ -2954,5 +2951,3 @@ t8_forest_element_has_leaf_desc (t8_forest_t forest, t8_gloidx_t gtreeid,
   }
   return 0;
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -30,9 +30,6 @@
 #include <t8_element_cxx.hxx>
 #include <t8_data/t8_containers.h>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* The information for a remote process, what data
  * we have to send to them.
  */
@@ -2472,5 +2469,3 @@ t8_forest_ghost_destroy (t8_forest_ghost_t * pghost)
   t8_forest_ghost_unref (pghost);
   T8_ASSERT (*pghost == NULL);
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -25,9 +25,6 @@
 #include <t8_forest.h>
 #include <t8_element_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 typedef struct
 {
   t8_eclass_scheme_c *ts;
@@ -467,5 +464,3 @@ t8_forest_iterate_replace (t8_forest_t forest_new,
   }                             /* tree loop */
   t8_global_productionf ("Done t8_forest_iterate_replace\n");
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -27,9 +27,6 @@
 #include <t8_cmesh/t8_cmesh_offset.h>
 #include <t8_element_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* For each tree that we send elements from to
  * other processes, we send this information to the
  * other process */
@@ -1292,5 +1289,3 @@ t8_forest_partition_data (t8_forest_t forest_from, t8_forest_t forest_to,
   t8_log_indent_pop ();
   t8_global_productionf ("Done forest partition data.\n");
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_types.h
+++ b/src/t8_forest/t8_forest_types.h
@@ -35,6 +35,8 @@
 #include <t8_forest/t8_forest_adapt.h>
 #include <t8_forest.h>
 
+T8_EXTERN_C_BEGIN ();
+
 typedef struct t8_profile t8_profile_t; /* Defined below */
 typedef struct t8_forest_ghost *t8_forest_ghost_t;      /* Defined below */
 
@@ -211,5 +213,7 @@ typedef struct t8_forest_ghost
   sc_mempool_t       *glo_tree_mempool;
   sc_mempool_t       *proc_offset_mempool;
 } t8_forest_ghost_struct_t;
+
+T8_EXTERN_C_END ();
 
 #endif /* ! T8_FOREST_TYPES_H! */

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -62,9 +62,6 @@
 #include <t8_forest.h>
 #include <t8_schemes/t8_default_cxx.hxx>
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* TODO: Currently we only use ASCII mode and no data compression.
  *       We also do not use sc_io to buffer our output stream. */
 
@@ -1547,5 +1544,3 @@ t8_forest_vtk_failure:
   t8_errorf ("Error when writing vtk file.\n");
   return 0;
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_mesh.h
+++ b/src/t8_mesh.h
@@ -37,6 +37,8 @@
 
 #include <t8_element.h>
 
+T8_EXTERN_C_BEGIN ();
+
 typedef struct t8_mesh t8_mesh_t;
 
 /************************* preallocate **************************/
@@ -135,5 +137,7 @@ void                t8_mesh_get_element_support (t8_mesh_t * mesh,
 /***************************** destruct *************************/
 
 void                t8_mesh_destroy (t8_mesh_t * mesh);
+
+T8_EXTERN_C_END ();
 
 #endif /* !T8_MESH_H */

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -23,9 +23,6 @@
 #include <sc_functions.h>
 #include "t8_default_common_cxx.hxx"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /** This class independent function assumes an sc_mempool_t as context.
  * It is suitable as the elem_new callback in \ref t8_eclass_scheme_t.
  * We assume that the mempool has been created with the correct element size.
@@ -172,5 +169,3 @@ t8_default_scheme_common_c::t8_element_general_function (const t8_element_t *
 {
   /* This function is intentionally left blank. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_cxx.cxx
@@ -32,9 +32,6 @@
 #include "t8_default_tet_cxx.hxx"
 #include "t8_default_prism_cxx.hxx"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 t8_scheme_cxx_t    *
 t8_scheme_new_default_cxx (void)
 {
@@ -79,5 +76,3 @@ t8_eclass_scheme_is_default (t8_eclass_scheme_c * ts)
   }
   return 0;                     /* Default return value false */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
@@ -632,14 +632,27 @@ t8_default_scheme_hex_c::t8_element_successor (const t8_element_t * elem1,
                                                t8_element_t * elem2,
                                                int level)
 {
-  t8_linearidx_t      id;
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= P8EST_OLD_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DEFAULT_HEX_QMAXLEVEL);
 
-  id = p8est_quadrant_linear_id ((const p8est_quadrant_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << P8EST_DIM * level);
-  p8est_quadrant_set_morton ((p8est_quadrant_t *) elem2, level, id + 1);
+  const p8est_quadrant_t *src = (const p8est_quadrant_t *) elem1;
+  if (level == src->level) {
+    p8est_quadrant_successor (src, (p8est_quadrant_t *) elem2);
+  }
+  else {
+    p8est_quadrant_t interm;
+    if (level < src->level) {
+      p8est_quadrant_ancestor (src, level, &interm);
+    }
+    else {
+      T8_ASSERT (level > src->level);
+      interm = *src;
+      interm.level = level;
+      T8_ASSERT (p8est_quadrant_is_valid (&interm));
+    }
+    p8est_quadrant_successor (&interm, (p8est_quadrant_t *) elem2);
+  }
 }
 
 void

--- a/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
@@ -31,7 +31,13 @@ T8_EXTERN_C_BEGIN ();
 int
 t8_default_scheme_hex_c::t8_element_maxlevel (void)
 {
-  return P8EST_QMAXLEVEL;
+  return T8_DEFAULT_HEX_QMAXLEVEL;
+}
+
+int
+t8_default_scheme_hex_c::t8_element_maxlevel_linearid (void)
+{
+  return P8EST_OLD_QMAXLEVEL;
 }
 
 /* *INDENT-OFF* */
@@ -143,7 +149,7 @@ t8_default_scheme_hex_c::t8_element_child (const t8_element_t * elem,
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
   T8_ASSERT (p8est_quadrant_is_extended (q));
-  T8_ASSERT (q->level < P8EST_QMAXLEVEL);
+  T8_ASSERT (q->level < T8_DEFAULT_HEX_QMAXLEVEL);
   T8_ASSERT (0 <= childid && childid < P8EST_CHILDREN);
 
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
@@ -438,7 +444,7 @@ t8_default_scheme_hex_c::t8_element_first_descendant_face (const t8_element_t
   int                 first_face_corner;
 
   T8_ASSERT (0 <= face && face < P8EST_FACES);
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DEFAULT_HEX_QMAXLEVEL);
 
   /* Get the first corner of q that belongs to face */
   first_face_corner = p8est_face_corners[face][0];
@@ -459,7 +465,7 @@ t8_default_scheme_hex_c::t8_element_last_descendant_face (const t8_element_t *
   int                 last_face_corner;
 
   T8_ASSERT (0 <= face && face < P8EST_FACES);
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DEFAULT_HEX_QMAXLEVEL);
 
   /* Get the last corner of q that belongs to face */
   last_face_corner = p8est_face_corners[face][3];
@@ -582,7 +588,7 @@ t8_default_scheme_hex_c::t8_element_set_linear_id (t8_element_t * elem,
                                                    t8_linearidx_t id)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= P8EST_OLD_QMAXLEVEL);
   T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << P8EST_DIM * level);
 
   p8est_quadrant_set_morton ((p8est_quadrant_t *) elem, level, id);
@@ -593,7 +599,7 @@ t8_linearidx_t
                                                      elem, int level)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= P8EST_OLD_QMAXLEVEL);
 
   return p8est_quadrant_linear_id ((p8est_quadrant_t *) elem, level);
 }
@@ -606,7 +612,7 @@ t8_default_scheme_hex_c::t8_element_first_descendant (const t8_element_t *
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DEFAULT_HEX_QMAXLEVEL);
   p8est_quadrant_first_descendant ((p8est_quadrant_t *) elem,
                                    (p8est_quadrant_t *) desc, level);
 }
@@ -619,7 +625,7 @@ t8_default_scheme_hex_c::t8_element_last_descendant (const t8_element_t *
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DEFAULT_HEX_QMAXLEVEL);
   p8est_quadrant_last_descendant ((p8est_quadrant_t *) elem,
                                   (p8est_quadrant_t *) desc, level);
 }
@@ -632,7 +638,7 @@ t8_default_scheme_hex_c::t8_element_successor (const t8_element_t * elem1,
   t8_linearidx_t      id;
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= P8EST_OLD_QMAXLEVEL);
 
   id = p8est_quadrant_linear_id ((const p8est_quadrant_t *) elem1, level);
   T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << P8EST_DIM * level);

--- a/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex_cxx.cxx
@@ -25,9 +25,6 @@
 #include "t8_default_common_cxx.hxx"
 #include "t8_default_hex_cxx.hxx"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 int
 t8_default_scheme_hex_c::t8_element_maxlevel (void)
 {
@@ -748,5 +745,3 @@ t8_default_scheme_hex_c::~t8_default_scheme_hex_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex_cxx.hxx
@@ -51,6 +51,7 @@ public:
   /** Constructor. */
   t8_default_scheme_hex_c ();
 
+  /** Destructor. */
   ~t8_default_scheme_hex_c ();
 
   /** Allocate memory for a given number of elements.

--- a/src/t8_schemes/t8_default/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex_cxx.hxx
@@ -30,6 +30,13 @@
 #include <t8_element_cxx.hxx>
 #include "t8_default_quad_cxx.hxx"
 
+/** Introduce hex maxlevel definition to facilitate future changes.
+ * p8est now allows for changing its maxlevel to P8EST_QMAXLEVEL.
+ * However, this is greater than legal for linar id functions.
+ * t8code linear id handling would need to be updated first.
+ */
+#define T8_DEFAULT_HEX_QMAXLEVEL P8EST_OLD_QMAXLEVEL
+
 /** The structure holding a hexahedral element in the default scheme.
  * We make this definition public for interoperability of element classes.
  * We might want to put this into a private, scheme-specific header file.
@@ -57,6 +64,9 @@ public:
 
 /** Return the maximum level allowed for this element class. */
   virtual int         t8_element_maxlevel (void);
+
+/** Return the maximum level allowed for linear id functions. */
+  virtual int         t8_element_maxlevel_linearid (void);
 
 /** Return the type of each child in the ordering of the implementation. */
   virtual t8_eclass_t t8_element_child_eclass (int childid);

--- a/src/t8_schemes/t8_default/t8_default_line.h
+++ b/src/t8_schemes/t8_default/t8_default_line.h
@@ -1,0 +1,34 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#ifndef T8_DEFAULT_LINE_H
+#define T8_DEFAULT_LINE_H
+
+#include <t8.h>
+
+T8_EXTERN_C_BEGIN ();
+
+int t8_default_line_dummy;
+
+T8_EXTERN_C_END ();
+
+#endif /* T8_DEFAULT_LINE_H */

--- a/src/t8_schemes/t8_default/t8_default_line_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_line_cxx.cxx
@@ -28,8 +28,6 @@
 
 typedef t8_dline_t  t8_default_line_t;
 
-T8_EXTERN_C_BEGIN ();
-
 int
 t8_default_scheme_line_c::t8_element_maxlevel (void)
 {
@@ -493,5 +491,3 @@ t8_default_scheme_line_c::~t8_default_scheme_line_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_prism_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_prism_cxx.cxx
@@ -27,8 +27,6 @@
 
 typedef t8_dprism_t t8_default_prism_t;
 
-T8_EXTERN_C_BEGIN ();
-
 void
 t8_default_scheme_prism_c::t8_element_new (int length, t8_element_t ** elem)
 {
@@ -438,5 +436,3 @@ t8_default_scheme_prism_c::~t8_default_scheme_prism_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad_cxx.cxx
@@ -324,15 +324,27 @@ t8_default_scheme_quad_c::t8_element_successor (const t8_element_t * elem1,
                                                 t8_element_t * elem2,
                                                 int level)
 {
-  t8_linearidx_t      id;
-
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
   T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
 
-  id = p4est_quadrant_linear_id ((const p4est_quadrant_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << P4EST_DIM * level);
-  p4est_quadrant_set_morton ((p4est_quadrant_t *) elem2, level, id + 1);
+  const p4est_quadrant_t *src = (const p4est_quadrant_t *) elem1;
+  if (level == src->level) {
+    p4est_quadrant_successor (src, (p4est_quadrant_t *) elem2);
+  }
+  else {
+    p4est_quadrant_t interm;
+    if (level < src->level) {
+      p4est_quadrant_ancestor (src, level, &interm);
+    }
+    else {
+      T8_ASSERT (level > src->level);
+      interm = *src;
+      interm.level = level;
+      T8_ASSERT (p4est_quadrant_is_valid (&interm));
+    }
+    p4est_quadrant_successor (&interm, (p4est_quadrant_t *) elem2);
+  }
   t8_element_copy_surround ((const p4est_quadrant_t *) elem1,
                             (p4est_quadrant_t *) elem2);
 }

--- a/src/t8_schemes/t8_default/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad_cxx.cxx
@@ -25,9 +25,6 @@
 #include "t8_default_common_cxx.hxx"
 #include "t8_default_quad_cxx.hxx"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 /* This function is used by other element functions and we thus need to
  * declare it up here */
 t8_linearidx_t      t8_element_get_linear_id (const t8_element_t * elem,
@@ -864,5 +861,3 @@ t8_default_scheme_quad_c::~t8_default_scheme_quad_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_tet_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tet_cxx.cxx
@@ -26,9 +26,6 @@
 #include "t8_dtri_bits.h"
 #include "t8_dtet_connectivity.h"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 typedef t8_dtet_t   t8_default_tet_t;
 
 int
@@ -608,5 +605,3 @@ t8_default_scheme_tet_c::~t8_default_scheme_tet_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_tri_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_tri_cxx.cxx
@@ -27,9 +27,6 @@
 #include "t8_dtet.h"
 #include "t8_dtri_connectivity.h"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 int
 t8_default_scheme_tri_c::t8_element_maxlevel (void)
 {
@@ -628,5 +625,3 @@ t8_default_scheme_tri_c::~t8_default_scheme_tri_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_vertex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_vertex_cxx.cxx
@@ -24,9 +24,6 @@
 #include "t8_default_vertex_cxx.hxx"
 #include "t8_dvertex_bits.h"
 
-/* We want to export the whole implementation to be callable from "C" */
-T8_EXTERN_C_BEGIN ();
-
 int
 t8_default_scheme_vertex_c::t8_element_maxlevel (void)
 {
@@ -354,5 +351,3 @@ t8_default_scheme_vertex_c::~t8_default_scheme_vertex_c ()
    * However we need to provide an implementation of the destructor
    * and hence this empty function. */
 }
-
-T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_dline.h
+++ b/src/t8_schemes/t8_default/t8_dline.h
@@ -29,6 +29,8 @@
 
 #include <t8.h>
 
+T8_EXTERN_C_BEGIN ();
+
 /** The number of children that a line is refined into. */
 #define T8_DLINE_CHILDREN 2
 
@@ -55,5 +57,7 @@ typedef struct t8_dline
   t8_dline_coord_t    x;
 }
 t8_dline_t;
+
+T8_EXTERN_C_END ();
 
 #endif /* T8_DLINE_H */

--- a/src/t8_schemes/t8_default/t8_dprism.h
+++ b/src/t8_schemes/t8_default/t8_dprism.h
@@ -31,6 +31,8 @@
 #include "t8_dline.h"
 #include "t8_dtri.h"
 
+T8_EXTERN_C_BEGIN ();
+
 /** The number of children that a prism is refined into. */
 #define T8_DPRISM_CHILDREN 8
 
@@ -69,5 +71,7 @@ typedef struct t8_dprism
   t8_dtri_t           tri;      /*x,y coordinate + level + type */
 }
 t8_dprism_t;
+
+T8_EXTERN_C_END ();
 
 #endif /* T8_DPRISM_H */

--- a/src/t8_schemes/t8_default/t8_dtet.h
+++ b/src/t8_schemes/t8_default/t8_dtet.h
@@ -31,6 +31,8 @@
  * TODO: document this.
  */
 
+T8_EXTERN_C_BEGIN ();
+
 /** The number of children that a tetrahedron is refined into. */
 #define T8_DTET_CHILDREN 8
 
@@ -84,5 +86,7 @@ typedef struct t8_dtet
   t8_dtet_coord_t     z;        /**< The z integer coordinate of the anchor node. */
 }
 t8_dtet_t;
+
+T8_EXTERN_C_END ();
 
 #endif /* T8_DTET_H */

--- a/src/t8_schemes/t8_default/t8_dvertex.h
+++ b/src/t8_schemes/t8_default/t8_dvertex.h
@@ -29,6 +29,8 @@
 
 #include <t8.h>
 
+T8_EXTERN_C_BEGIN ();
+
 /** The number of children that a vertex is refined into. */
 #define T8_DVERTEX_CHILDREN 1
 
@@ -49,5 +51,7 @@ typedef struct t8_dvertex
   uint8_t             level;
 }
 t8_dvertex_t;
+
+T8_EXTERN_C_END ();
 
 #endif /* T8_DVERTEX_H */

--- a/src/t8_schemes/t8_default_cxx.hxx
+++ b/src/t8_schemes/t8_default_cxx.hxx
@@ -31,8 +31,6 @@
 
 #include <t8_element_cxx.hxx>
 
-T8_EXTERN_C_BEGIN ();
-
 /** Return the default element implementation of t8code. */
 t8_scheme_cxx_t    *t8_scheme_new_default_cxx (void);
 
@@ -42,7 +40,5 @@ t8_scheme_cxx_t    *t8_scheme_new_default_cxx (void);
  *                  false (zero) otherwise.
  */
 int                 t8_eclass_scheme_is_default (t8_eclass_scheme_c *ts);
-
-T8_EXTERN_C_END ();
 
 #endif /* !T8_DEFAULT_H */


### PR DESCRIPTION
Update p4est and libsc to latest prev3-develop branches, align t8code.

Propose a maxlevel_linearid function since higher maxlevels than ~20 in 3D shapes lead to linear indices bigger than 64 bits. One solution would be to bump the linear id to a 128 bit type using sc_uint128.h. The other would be to partition to maxlevel ~20 boundaries, or specifically to the minimum of maxlevel_linearid over all shapes, even though the refinement reaches higher levels. Is there actually a way of partitioning that would not explicitly use linear id arithmetic? For now, the p8est maxlevel remains artificially limited to the old value of 19 to keep everything working.

Now using  the p4est builtin successor functions. All tests run ok.